### PR TITLE
Styles for edit, delete, and display user directions views

### DIFF
--- a/app/views/addresses/_form.html.erb
+++ b/app/views/addresses/_form.html.erb
@@ -1,34 +1,38 @@
-<%= form_for(@address) do |f| %>
-<%= render "/devise/shared/error_messages", resource: @address %>
-  <div>
-    <%= f.label :city %>
-      <%= f.text_field :city %>
-  </div>
+<div class="row offset-md-3 col-md-6">
+  <%= form_for(@address) do |f| %>
+    <%= render "/devise/shared/error_messages", resource: @address %>
+    <div class="my-3">
+      <%= f.label :city %>
+      <%= f.text_field :city, class: "w-100 form-control" %>
+    </div>
 
-  <div>
-    <%= f.label :state %>
-      <%= f.text_field :state %>
-  </div>
+    <div>
+      <%= f.label :state %>
+      <%= f.text_field :state, class: "w-100 form-control" %>
+    </div>
 
-  <div>
-    <%= f.label :zip_code %>
-      <%= f.number_field :zip_code %>
-  </div>
+    <div class="my-3">
+      <%= f.label :zip_code %>
+      <%= f.number_field :zip_code, class: "w-100 form-control" %>
+    </div>
 
-  <div>
-    <%= f.label :address %>
-      <%= f.text_area :address %>
-  </div>
+    <div>
+      <%= f.label :address %>
+      <%= f.text_area :address, class: "w-100 form-control" %>
+    </div>
 
-  <div>
-    <%= f.label :phone_number %>
-      <%= f.text_field :phone_number %>
-  </div>
+    <div class="my-3">
+      <%= f.label :phone_number %>
+      <%= f.text_field :phone_number, class: "w-100 form-control" %>
+    </div>
 
-  <div>
-    <%= f.submit "Crear Dirección" %>
-  </div>
+    <div class="text-center">
+      <%= f.submit "Save Address", class: "btn btn-login text-uppercase fw-bold my-3" %>
+      <%= button_tag "Clear Fields", type: "reset", class: "btn btn-secondary text-uppercase fw-bold my-3 mx-2" %>
+    </div>
   <% end %>
+</div>
+
 
 <div class="container py-5">
   <div class="row d-flex justify-content-center align-items-center">

--- a/app/views/addresses/edit.html.erb
+++ b/app/views/addresses/edit.html.erb
@@ -1,2 +1,6 @@
-<h1>Edit Address</h1>
-<%= render "form", address: @address %>
+<div class="container">
+  <div class="text-center">
+    <h1 class="my-5 login-heading mb-4 fw-medium fs-1 fw-light">Edit Address</h1>
+  </div>
+    <%= render "form", address: @address %>
+</div>

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -8,9 +8,9 @@
   </div>
 
   <div class="table-responsive">
-    <table class="table table-hover text-center mb-5">
+    <table class="table table-hover mb-5">
       <thead>
-        <tr>
+        <tr class="d-none d-md-table-row">
           <th>City</th>
           <th>State</th>
           <th>ZIP Code</th>
@@ -22,23 +22,38 @@
       <tbody>
         <% @addresses.each do |address| %>
           <tr>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <%= address.city %>
             </td>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <%= address.state %>
             </td>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <%= address.zip_code %>
             </td>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <%= address.address %>
             </td>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <%= address.phone_number %>
             </td>
-            <td class="align-middle">
+            <td class="d-none d-md-table-cell">
               <div class="btn-group">
+                <%= link_to edit_address_path(address), class: "btn btn-primary" do %>
+                  <i class="fas fa-edit"></i> Edit
+                <% end %>
+                <%= link_to address_path(address), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" do %>
+                  <i class="fas fa-trash"></i> Delete
+                <% end %>
+              </div>
+            </td>
+            <td class="d-table-cell d-md-none" colspan="2">
+              <strong>City:</strong> <%= address.city %><br>
+              <strong>State:</strong> <%= address.state %><br>
+              <strong>ZIP Code:</strong> <%= address.zip_code %><br>
+              <strong>Address:</strong> <%= address.address %><br>
+              <strong>Phone Number:</strong> <%= address.phone_number %><br>
+              <div class="btn-group mt-2">
                 <%= link_to edit_address_path(address), class: "btn btn-primary" do %>
                   <i class="fas fa-edit"></i> Edit
                 <% end %>

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -1,40 +1,55 @@
-<h1>Address List</h1>
-<%= link_to 'New Address' , new_address_path %>
-<table>
-  <thead>
-    <tr>
-      <th>City</th>
-      <th>State</th>
-      <th>ZIP Code</th>
-      <th>Address</th>
-      <th>Phone Number</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @addresses.each do |address| %>
-      <tr>
-        <td>
-          <%= address.city %>
-        </td>
-        <td>
-          <%= address.state %>
-        </td>
-        <td>
-          <%= address.zip_code %>
-        </td>
-        <td>
-          <%= address.address %>
-        </td>
-        <td>
-          <%= address.phone_number %>
-        </td>
-        <td>
-          <%= link_to "Edit", edit_address_path(address) %>
-          <%= link_to "Delete", address_path(address), method: :delete, data: { turbo_method: :delete,
-            turbo_confirm: "Are you sure?" } %>
-        </td>
-      </tr>
-      <% end %>
-  </tbody>
-</table>
+<div class="container">
+  <div class="text-center">
+    <h1 class="my-5 login-heading mb-4 fw-medium fs-1 fw-light">Address List</h1>
+  </div>
+
+  <div class="my-5">
+    <%= link_to 'New Address', new_address_path, class: "btn btn-login text-uppercase fw-bold"  %>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-hover text-center mb-5">
+      <thead>
+        <tr>
+          <th>City</th>
+          <th>State</th>
+          <th>ZIP Code</th>
+          <th>Address</th>
+          <th>Phone Number</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @addresses.each do |address| %>
+          <tr>
+            <td class="align-middle">
+              <%= address.city %>
+            </td>
+            <td class="align-middle">
+              <%= address.state %>
+            </td>
+            <td class="align-middle">
+              <%= address.zip_code %>
+            </td>
+            <td class="align-middle">
+              <%= address.address %>
+            </td>
+            <td class="align-middle">
+              <%= address.phone_number %>
+            </td>
+            <td class="align-middle">
+              <div class="btn-group">
+                <%= link_to edit_address_path(address), class: "btn btn-primary" do %>
+                  <i class="fas fa-edit"></i> Edit
+                <% end %>
+                <%= link_to address_path(address), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-danger" do %>
+                  <i class="fas fa-trash"></i> Delete
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/addresses/new.html.erb
+++ b/app/views/addresses/new.html.erb
@@ -1,2 +1,6 @@
-<h1>New Address</h1>
-<%= render "form", address: @address %>
+<div class="container">
+  <div class="text-center">
+    <h1 class="my-5 login-heading mb-4 fw-medium fs-1 fw-light">New Address</h1>
+  </div>
+  <%= render "form", address: @address %>
+</div>


### PR DESCRIPTION
# Description

What did you implement/Why did you implement this?

- Added styling to address view. When the user logs in and clicks on their profile, they are allowed to generate, edit and delete the addresses associated with their account.
- Added a button to clean the fields when the user creates an address.

## Screenshots

![image](https://github.com/BrightCoders-Institute/proyecto-final-jdg/assets/6729543/6de4a18a-9b84-4b8e-9e0e-ddd7d5e72e81)

![image](https://github.com/BrightCoders-Institute/proyecto-final-jdg/assets/6729543/0853d5a4-50c2-4182-89b8-936c039ff6ca)

![image](https://github.com/BrightCoders-Institute/proyecto-final-jdg/assets/6729543/8789f45b-2f24-45b3-8708-9fc8d7aeef1d)

![image](https://github.com/BrightCoders-Institute/proyecto-final-jdg/assets/6729543/3fb206c0-d2a0-42aa-8580-2096c8a8f9ff)
